### PR TITLE
Fix: golangci-lint warnings

### DIFF
--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -6,6 +6,8 @@ linters:
     - gocyclo
     # Inspects source code for security problems.
     - gosec
+    # Checks code formatting
+    - goimports
 
 issues:
   # Disable max issues per linter.

--- a/src/cmd/leadership-election/app/agent.go
+++ b/src/cmd/leadership-election/app/agent.go
@@ -98,7 +98,7 @@ func WithMetrics(m Metrics) AgentOption {
 
 // Start starts the Agent. It does not block.
 func (a *Agent) Start(caFile, certFile, keyFile string) {
-	tlsConfig, err := buildTLSConfig(caFile, certFile, keyFile)
+	tlsConfig := buildTLSConfig(caFile, certFile, keyFile)
 
 	lis, err := tls.Listen("tcp", fmt.Sprintf("localhost:%d", a.port), tlsConfig)
 	if err != nil {
@@ -143,7 +143,7 @@ func leaderStatusServer(isLeader func() bool) *http.Server {
 	return srv
 }
 
-func buildTLSConfig(caFile, certFile, keyFile string) (*tls.Config, error) {
+func buildTLSConfig(caFile, certFile, keyFile string) *tls.Config {
 	tlsConfig, err := tlsconfig.Build(
 		tlsconfig.WithInternalServiceDefaults(),
 		tlsconfig.WithIdentityFromFile(certFile, keyFile),
@@ -153,7 +153,7 @@ func buildTLSConfig(caFile, certFile, keyFile string) (*tls.Config, error) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	return tlsConfig, err
+	return tlsConfig
 }
 
 func (a *Agent) startRaft() func() bool {

--- a/src/cmd/leadership-election/main.go
+++ b/src/cmd/leadership-election/main.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"os"
 
-	_ "net/http/pprof"
+	_ "net/http/pprof" //nolint:gosec
 
 	"code.cloudfoundry.org/go-envstruct"
 	metrics "code.cloudfoundry.org/go-metric-registry"
@@ -22,7 +22,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	envstruct.WriteReport(&cfg)
+	envstruct.WriteReport(&cfg) //nolint:errcheck
 
 	logger := log.New(os.Stderr, "", log.LstdFlags)
 	m := metrics.NewRegistry(

--- a/src/cmd/metric-scraper/app/config.go
+++ b/src/cmd/metric-scraper/app/config.go
@@ -54,7 +54,7 @@ func LoadConfig(log *log.Logger) Config {
 		log.Fatal(err)
 	}
 
-	envstruct.WriteReport(&cfg)
+	envstruct.WriteReport(&cfg) //nolint:errcheck
 
 	return cfg
 }

--- a/src/cmd/metric-scraper/app/metric_scraper_test.go
+++ b/src/cmd/metric-scraper/app/metric_scraper_test.go
@@ -312,6 +312,7 @@ func createDNSFile(URL string) string {
 	tmpfn, err = filepath.Abs(tmpfn)
 	Expect(err).ToNot(HaveOccurred())
 
+	//nolint:gosec
 	if err := ioutil.WriteFile(tmpfn, []byte(contents), 0666); err != nil {
 		log.Fatal(err)
 	}
@@ -401,7 +402,8 @@ func (s *promServer) handleRequest(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(toSleep)
 	}
 
-	w.Write([]byte(promOutput))
+	_, err := w.Write([]byte(promOutput))
+	Expect(err).NotTo(HaveOccurred())
 }
 
 func (s *promServer) start(testCerts *testhelper.TestCerts) {
@@ -462,7 +464,7 @@ func newSpyAgent(testCerts *testhelper.TestCerts) *spyAgent {
 	grpcServer := grpc.NewServer(grpc.Creds(serverCreds))
 	loggregator_v2.RegisterIngressServer(grpcServer, agent)
 
-	go grpcServer.Serve(lis)
+	go grpcServer.Serve(lis) //nolint:errcheck
 
 	return agent
 }

--- a/src/cmd/metric-scraper/main.go
+++ b/src/cmd/metric-scraper/main.go
@@ -72,7 +72,7 @@ func getTLSConfig(cfg app.Config) *tls.Config {
 		log.Fatal(err)
 	}
 
-	return &tls.Config{
+	return &tls.Config{ //nolint:gosec
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      caCertPool,
 	}

--- a/src/pkg/scraper/scraper.go
+++ b/src/pkg/scraper/scraper.go
@@ -148,7 +148,7 @@ func (s *Scraper) scrape(target Target) (map[string]*io_prometheus_client.Metric
 	}
 
 	defer func() {
-		io.Copy(ioutil.Discard, resp.Body)
+		io.Copy(ioutil.Discard, resp.Body) //nolint:errcheck
 		resp.Body.Close()
 	}()
 

--- a/src/pkg/scraper/scraper_test.go
+++ b/src/pkg/scraper/scraper_test.go
@@ -405,7 +405,7 @@ var _ = Describe("Scraper", func() {
 			addResponse(tc, 200, smallGaugeOutput)
 		}
 
-		go tc.scraper.Scrape()
+		go tc.scraper.Scrape() //nolint:errcheck
 
 		Eventually(func() int { return len(tc.metricGetter.addrs) }, 1).Should(Equal(3))
 	})


### PR DESCRIPTION
# Description

* Resolve `golangci-lint` warnings.
* Add a new linter `goimports` to check formatting.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes