### PR TITLE
Fix: parallel testing

### DIFF
--- a/src/cmd/leadership-election/app/agent_test.go
+++ b/src/cmd/leadership-election/app/agent_test.go
@@ -28,6 +28,8 @@ var _ = Describe("Agent", func() {
 	)
 
 	BeforeEach(func() {
+		run += GinkgoParallelNode() * 15
+
 		agents = make(map[string]*app.Agent)
 
 		var ca *certtest.Authority


### PR DESCRIPTION
# Description

While running ginkgo with the `-p` flag we were getting the error:

```
Ginkgo timed out waiting for all parallel nodes to report back!
```

The Agent Suite includes two tests that listen on ports, which we were
hardcoding to 1000. When run in serial it was fine because an AfterEach
would increase them, but in parallel they would overlap.

Increased the port variable by the GinkgoParallelNode number times 15,
which should give plenty of space for the two tests to not overlap.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes