### PR TITLE
Don't report value of NATS_HOSTS environment variable

### DIFF
--- a/src/cmd/metric-scraper/app/config.go
+++ b/src/cmd/metric-scraper/app/config.go
@@ -36,7 +36,7 @@ type Config struct {
 
 	DNSFile string `env:"DNS_FILE, report, required"`
 
-	NatsHosts    []string `env:"NATS_HOSTS, required, report"`
+	NatsHosts    []string `env:"NATS_HOSTS, required"`
 	NatsCAPath   string   `env:"NATS_CA_PATH, required, report"`
 	NatsCertPath string   `env:"NATS_CERT_PATH, required, report"`
 	NatsKeyPath  string   `env:"NATS_KEY_PATH, required, report"`

--- a/src/cmd/metric-scraper/app/config_test.go
+++ b/src/cmd/metric-scraper/app/config_test.go
@@ -1,0 +1,67 @@
+package app_test
+
+import (
+	"bytes"
+	"log"
+	"os"
+
+	"code.cloudfoundry.org/go-envstruct"
+	"code.cloudfoundry.org/system-metrics-scraper/cmd/metric-scraper/app"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("configuration", func() {
+
+	var requiredVars = []string{
+		"CA_CERT_PATH",
+		"CLIENT_CERT_PATH",
+		"CLIENT_KEY_PATH",
+		"DEFAULT_SOURCE_ID",
+		"DNS_FILE",
+		"LEADERSHIP_ELECTION_CA_CERT_PATH",
+		"LEADERSHIP_ELECTION_CERT_PATH",
+		"LEADERSHIP_ELECTION_KEY_PATH",
+		"LEADERSHIP_SERVER_ADDR",
+		"LOGGREGATOR_AGENT_ADDR",
+		"METRICS_CA_FILE_PATH",
+		"METRICS_CERT_FILE_PATH",
+		"METRICS_KEY_FILE_PATH",
+		"NATS_CA_PATH",
+		"NATS_CERT_PATH",
+		"NATS_KEY_PATH",
+		"SCRAPE_PORT",
+		"SYSTEM_METRICS_CA_CERT_PATH",
+		"SYSTEM_METRICS_CA_CN",
+		"SYSTEM_METRICS_CERT_PATH",
+		"SYSTEM_METRICS_KEY_PATH",
+	}
+
+	BeforeEach(func() {
+		err := os.Setenv("NATS_HOSTS", "some-secret")
+		Expect(err).ToNot(HaveOccurred())
+
+		for _, v := range requiredVars {
+			err := os.Setenv(v, "1234")
+			Expect(err).ToNot(HaveOccurred())
+		}
+	})
+	AfterEach(func() {
+		err := os.Unsetenv("NATS_HOSTS")
+		Expect(err).ToNot(HaveOccurred())
+
+		for _, v := range requiredVars {
+			err := os.Unsetenv(v)
+			Expect(err).ToNot(HaveOccurred())
+		}
+	})
+
+	It("does not report the value of the NATS_HOSTS environment variable", func() {
+		var output bytes.Buffer
+		envstruct.ReportWriter = &output
+		logger := log.New(GinkgoWriter, "", log.LstdFlags)
+		app.LoadConfig(logger)
+		Expect(output.String()).ToNot(ContainSubstring("some-secret"))
+	})
+
+})


### PR DESCRIPTION
# Description

Modifies the reporting of environment variables on startup to not include the value of the `NATS_HOSTS` environment variable.

The unit test added modifies environment variables.

The placeholder value of "1234" is because the `SCRAPE_PORT` is an int. An alternative would be to use `some-value` for the strings and handle `SCRAPE_PORT` on its own.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [X] Unit tests
- [X] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [X] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
