### PR TITLE
Fix: replace extra config struct

### DIFF
--- a/src/cmd/leadership-election/app/config.go
+++ b/src/cmd/leadership-election/app/config.go
@@ -2,15 +2,8 @@ package app
 
 import (
 	envstruct "code.cloudfoundry.org/go-envstruct"
+	"code.cloudfoundry.org/system-metrics-scraper/pkg/config"
 )
-
-// MetricsServer stores the configuration for the metrics server
-type MetricsServer struct {
-	Port     uint16 `env:"METRICS_PORT, report"`
-	CAFile   string `env:"METRICS_CA_FILE_PATH, required, report"`
-	CertFile string `env:"METRICS_CERT_FILE_PATH, required, report"`
-	KeyFile  string `env:"METRICS_KEY_FILE_PATH, required, report"`
-}
 
 type Config struct {
 	// Port is the HTTP port that the agent will bind to for localhost (e.g,
@@ -38,7 +31,7 @@ type Config struct {
 	CertFile string `env:"CERT_FILE, required, report"`
 	KeyFile  string `env:"KEY_FILE, required, report"`
 
-	MetricsServer MetricsServer
+	MetricsServer config.MetricsServer
 }
 
 func LoadConfig() (Config, error) {


### PR DESCRIPTION
# Description

Replace MetricServer in leadership-election with that in config package

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
