### PR TITLE
CI: use regex for release branches in actions triggers

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
     - main
-    - v2.0.x
+    - v[0-9]*
   pull_request:
     branches:
     - main
-    - v2.0.x
+    - v[0-9]*
 
 jobs:
   test:


### PR DESCRIPTION
# Description

Use the same regex that we use for branch protections for our GH actions triggers. This makes it so that when we split out version branches in the future, GH actions will successfully work on those branches out of the box.

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
