### PR TITLE
Change default scrape port in the spec

### DIFF
--- a/jobs/loggr-system-metric-scraper/spec
+++ b/jobs/loggr-system-metric-scraper/spec
@@ -41,7 +41,7 @@ properties:
     default: 1m
   scrape_port:
     description: "The port where the scraping endpoints are hosted"
-    default: 9100
+    default: 53035
 
   system_metrics.tls.common_name:
     description: "Common name for system metrics agent CA"


### PR DESCRIPTION
# Description

The default scrape port in the spec had to be changed as the port 9100 is used by OTel collector.
This is not critical or breaking change as in the ops file and in the cf-deployment the port 53035 is already used


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [X] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [X] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
