### PR TITLE
fix: Increase scraper timeout

### DIFF
--- a/src/cmd/metric-scraper/app/config.go
+++ b/src/cmd/metric-scraper/app/config.go
@@ -47,7 +47,7 @@ type Config struct {
 func LoadConfig(log *log.Logger) Config {
 	cfg := Config{
 		ScrapeInterval: time.Minute,
-		ScrapeTimeout:  time.Second,
+		ScrapeTimeout:  time.Minute,
 	}
 
 	if err := envstruct.Load(&cfg); err != nil {

--- a/src/cmd/metric-scraper/app/metric_scraper.go
+++ b/src/cmd/metric-scraper/app/metric_scraper.go
@@ -3,7 +3,6 @@ package app
 import (
 	"io"
 	"log"
-	"net"
 	"net/http"
 	"time"
 
@@ -174,19 +173,8 @@ func newTLSClient(cfg Config) *http.Client {
 		log.Panicf("failed to load API client certificates: %s", err)
 	}
 
-	transport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   cfg.ScrapeTimeout,
-			KeepAlive: 30 * time.Second,
-			DualStack: true,
-		}).DialContext,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-		TLSClientConfig:       tlsConfig,
-	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
 
 	return &http.Client{
 		Transport: transport,


### PR DESCRIPTION
# Description

A `ScraperTimeout` of one second appears to be too short a timeout, as we've seen instances (especially in more heavily loaded foundations) where the scraper error logs include the following:
```
2023/09/18 17:45:18 failed to scrape: scrape errors:
[id: control, instance_id: , metric_url: https://10.0.4.9:53035/metrics]: Get "https://10.0.4.9:53035/metrics": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
[id: control, instance_id: , metric_url: https://10.0.4.8:53035/metrics]: Get "https://10.0.4.8:53035/metrics": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

Increasing it to one minute, the same as `ScrapeInterval` was somewhat arbitrary, but we justified it by thinking: let the request run until its time to scrape again.

While we were here, we also realized that this transport was an outdated copy of `http.DefaultTransport`, so we updated it to use the latest values.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
