### PR TITLE
Bump to Go1.22

### DIFF
--- a/packages/golang-1.21-linux/spec.lock
+++ b/packages/golang-1.21-linux/spec.lock
@@ -1,2 +1,0 @@
-name: golang-1.21-linux
-fingerprint: 55147e471cfe150f63898ed1ae13b6cb48dac8f198d415319b14572ea7a55443

--- a/packages/leadership-election/packaging
+++ b/packages/leadership-election/packaging
@@ -1,6 +1,6 @@
 set -ex
 
-source /var/vcap/packages/golang-1.21-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.22-linux/bosh/compile.env
 export GOPATH=/var/vcap
 
 go build -mod=vendor -o ${BOSH_INSTALL_TARGET}/leadership-election ./cmd/leadership-election/

--- a/packages/leadership-election/spec
+++ b/packages/leadership-election/spec
@@ -2,7 +2,7 @@
 name: leadership-election
 
 dependencies:
-- golang-1.21-linux
+- golang-1.22-linux
 
 files:
 - cmd/leadership-election/**/*.go

--- a/packages/metric-scraper/packaging
+++ b/packages/metric-scraper/packaging
@@ -1,6 +1,6 @@
 set -ex
 
-source /var/vcap/packages/golang-1.21-linux/bosh/compile.env
+source /var/vcap/packages/golang-1.22-linux/bosh/compile.env
 export GOPATH=/var/vcap
 
 go build -mod=vendor -o ${BOSH_INSTALL_TARGET}/metric-scraper ./cmd/metric-scraper

--- a/packages/metric-scraper/spec
+++ b/packages/metric-scraper/spec
@@ -2,7 +2,7 @@
 name: metric-scraper
 
 dependencies:
-- golang-1.21-linux
+- golang-1.22-linux
 files:
 - cmd/metric-scraper/**/*.go
 - pkg/**/*.go

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module code.cloudfoundry.org/system-metrics-scraper
 
-go 1.21
+go 1.22
 
 require (
 	code.cloudfoundry.org/go-envstruct v1.7.0


### PR DESCRIPTION
# Description

- Removes go1.21 packages
- Uses go1.22 packages to build the other packages
- Specify go1.22 as the go version in src/go.mod

## Type of change

- [x] Maintenance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

- [x] Unit tests
- [x] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [ ] I have made corresponding changes to the documentation
- [ ] I have added testing for my changes

If you have any questions, or want to get attention for a PR or issue please reach out on the [#logging-and-metrics channel in the cloudfoundry slack](https://cloudfoundry.slack.com/archives/CUW93AF3M)
