### PR TITLE
Move to golangci v2

### DIFF
--- a/scripts/subtests/lint
+++ b/scripts/subtests/lint
@@ -9,7 +9,7 @@ set +e
 golangci_lint_executable=$(which golangci-lint)
 set -e
 if [ -z "${golangci_lint_executable}" ] || [ ! -x "${golangci_lint_executable}" ]; then
-  go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+  go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 fi
 
 pushd "${SCRIPT_DIR}/../../src" > /dev/null

--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 run:
   # Timeout for analysis, e.g. 30s, 5m.
   # Default: 1m
@@ -11,11 +13,31 @@ linters:
     - gocyclo
     # Inspects source code for security problems.
     - gosec
-    # Checks code formatting
-    - goimports
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
 
 issues:
   # Disable max issues per linter.
   max-issues-per-linter: 0
   # Disable max same issues.
   max-same-issues: 0
+
+formatters:
+  enable:
+    # Checks code formatting
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
# Description

Move to golangci-lint v2.

Noteworthy changes in golangci-lint v2:

* New config format (migrated with `migrate` command)
* Default timeout is now 0 instead of 1 minute. See [here](https://github.com/golangci/golangci-lint/pull/5470/commits/d3bf353d4531c824201394821f0119a690a01519#r1968522617) for rationale. Kept ours unchanged for now.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing performed?

NOTE: Requires #274 for unit tests to run through (tested locally)

- [x] Unit tests
- [ ] Integration tests
- [ ] Acceptance tests

## Checklist:

- [x] This PR is being made against the `main` branch, or relevant version branch
- [x] I have made corresponding changes to the documentation
- [x] I have added testing for my changes